### PR TITLE
edit-font-awesome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,8 +75,6 @@ end
 
 gem 'haml-rails'
 gem 'erb2haml'
-gem "font-awesome-sass", '~> 5.4.1'
-gem 'compass-rails','3.1.0'
 gem 'kaminari'
 gem 'pry-rails'
 gem 'jquery-rails'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,5 +7,6 @@
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous"
   %body
     = yield


### PR DESCRIPTION
#WHAT
font-awesome関連のgem削除
application.hamlにfont-awesomeのリンクを記述
#WHY
font-awesome実装のため